### PR TITLE
Add ability to build from command line with "swift build"

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftPM",
+        "repositoryURL": "https://github.com/apple/swift-package-manager",
+        "state": {
+          "branch": "4d0bab2",
+          "revision": "4d0bab2add46e3704343268227451534c224111c",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.1
+import PackageDescription
+
+let package = Package(
+    name: "location",
+    platforms: [
+        .macOS(.v10_13),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-package-manager", .revision("4d0bab2")),
+    ],
+    targets: [
+        .target(
+            name: "CoreLocationCLI",
+            dependencies: ["Utility"]),
+    ]
+)

--- a/Sources/CoreLocationCLI
+++ b/Sources/CoreLocationCLI
@@ -1,0 +1,1 @@
+../CoreLocationCLI


### PR DESCRIPTION
e.g. `swift build --disable-sandbox -c release --static-swift-stdlib`

This allows scripts and those without Mac developer accounts to build this code from the command line.

That ability can be helpful to homebrew, for example, as seen in the formula published for a similar program, "location":

https://github.com/kiliankoe/location/tree/master/Formula