### PR TITLE
Use inferred timezone for time field in output

### DIFF
--- a/CoreLocationCLI/main.swift
+++ b/CoreLocationCLI/main.swift
@@ -50,6 +50,18 @@ class Delegate: NSObject, CLLocationManagerDelegate {
             ? ""
             : CNPostalAddressFormatter.string(from: placemark!.postalAddress!, style: CNPostalAddressFormatterStyle.mailingAddress)
 
+        // Attempt to infer timezone for timestamp string
+        var locatedTime: String?
+        if let locatedTimeZone = placemark?.timeZone {
+            let time = location.timestamp
+
+            let formatter = DateFormatter()
+            formatter.timeZone = locatedTimeZone
+            formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+
+            locatedTime = formatter.string(from: time)
+        }
+
         switch format {
         case .json:
             let outputObject: [String: String?] = [
@@ -60,7 +72,7 @@ class Delegate: NSObject, CLLocationManagerDelegate {
                 "speed": "\(Int(location.speed))",
                 "h_accuracy": "\(Int(location.horizontalAccuracy))",
                 "v_accuracy": "\(Int(location.verticalAccuracy))",
-                "time": location.timestamp.description,
+                "time": locatedTime ?? location.timestamp.description,
 
                 // Placemark
                 "name": placemark?.name,

--- a/CoreLocationCLI/main.swift
+++ b/CoreLocationCLI/main.swift
@@ -101,7 +101,7 @@ class Delegate: NSObject, CLLocationManagerDelegate {
             output = output.replacingOccurrences(of: "%speed", with: "\(Int(location.speed))")
             output = output.replacingOccurrences(of: "%h_accuracy", with: "\(Int(location.horizontalAccuracy))")
             output = output.replacingOccurrences(of: "%v_accuracy", with: "\(Int(location.verticalAccuracy))")
-            output = output.replacingOccurrences(of: "%time", with: location.timestamp.description)
+            output = output.replacingOccurrences(of: "%time", with: locatedTime ?? location.timestamp.description)
 
             // Placemark
             output = output.replacingOccurrences(of: "%name", with: String(placemark?.name ?? ""))

--- a/CoreLocationCLI/main.swift
+++ b/CoreLocationCLI/main.swift
@@ -72,7 +72,7 @@ class Delegate: NSObject, CLLocationManagerDelegate {
                 "speed": "\(Int(location.speed))",
                 "h_accuracy": "\(Int(location.horizontalAccuracy))",
                 "v_accuracy": "\(Int(location.verticalAccuracy))",
-                "time": locatedTime ?? location.timestamp.description,
+                "time": location.timestamp.description,
 
                 // Placemark
                 "name": placemark?.name,
@@ -87,6 +87,7 @@ class Delegate: NSObject, CLLocationManagerDelegate {
                 "subThoroughfare": placemark?.subThoroughfare,
                 "region": placemark?.region?.identifier,
                 "timeZone": placemark?.timeZone?.identifier,
+                "time_local": locatedTime,
 
                 // Address
                 "address": formattedPostalAddress
@@ -101,7 +102,7 @@ class Delegate: NSObject, CLLocationManagerDelegate {
             output = output.replacingOccurrences(of: "%speed", with: "\(Int(location.speed))")
             output = output.replacingOccurrences(of: "%h_accuracy", with: "\(Int(location.horizontalAccuracy))")
             output = output.replacingOccurrences(of: "%v_accuracy", with: "\(Int(location.verticalAccuracy))")
-            output = output.replacingOccurrences(of: "%time", with: locatedTime ?? location.timestamp.description)
+            output = output.replacingOccurrences(of: "%time", with: location.timestamp.description)
 
             // Placemark
             output = output.replacingOccurrences(of: "%name", with: String(placemark?.name ?? ""))
@@ -116,6 +117,7 @@ class Delegate: NSObject, CLLocationManagerDelegate {
             output = output.replacingOccurrences(of: "%subThoroughfare", with: String(placemark?.subThoroughfare ?? ""))
             output = output.replacingOccurrences(of: "%region", with: String(placemark?.region?.identifier ?? ""))
             output = output.replacingOccurrences(of: "%timeZone", with: String(placemark?.timeZone?.identifier ?? ""))
+            output = output.replacingOccurrences(of: "%time_local", with: String(locatedTime ?? ""))
 
             // Address
             output = output.replacingOccurrences(of: "%address", with: formattedPostalAddress)
@@ -210,6 +212,7 @@ class Delegate: NSObject, CLLocationManagerDelegate {
             %subThoroughfare       Additional street-level information
             %region                Reverse geocoded geographic region
             %timeZone              Reverse geocoded time zone
+            %time_local            Localized time using reverse geocoded time zone
           -json                    Prints a JSON object with all information available
         
           Default format if not specified is: %latitude %longitude.
@@ -232,7 +235,7 @@ for (i, argument) in ProcessInfo().arguments.enumerated() {
     case "-format":
         if ProcessInfo().arguments.count > i+1 {
             delegate.format = .string(ProcessInfo().arguments[i+1])
-            let placemarkStrings = ["%address", "%name", "%isoCountryCode", "%country", "%postalCode", "%administrativeArea", "%subAdministrativeArea", "%locality", "%subLocality", "%thoroughfare", "%subThoroughfare", "%region", "%timeZone"]
+            let placemarkStrings = ["%address", "%name", "%isoCountryCode", "%country", "%postalCode", "%administrativeArea", "%subAdministrativeArea", "%locality", "%subLocality", "%thoroughfare", "%subThoroughfare", "%region", "%timeZone", "%time_local"]
             if placemarkStrings.contains(where:ProcessInfo().arguments[i+1].contains) {
                 delegate.requiresPlacemarkLookup = true
             }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ CoreLocationCLI [-follow] [-verbose] -json
 | `%subThoroughfare` | additional street-level information |
 | `%region` | Reverse geocoded geographic region |
 | `%timeZone` | Reverse geocoded time zone |
+| `%time_local` | Localized time using reverse geocoded time zone |
 
 The default format is: `%latitude %longitude`.
 
@@ -74,7 +75,7 @@ The default format is: `%latitude %longitude`.
 ```
 
 >```json
->{"address":"407 Keats Rd\nLower Moreland PA 19006\nUnited States","locality":"nLower Moreland","subThoroughfare":"407","time":"2019-10-03 04:10:05 +0000","subLocality":null,"administrativeArea":"PA","country":"United States","thoroughfare":"Keats Rd","region":"<+40.141196,-75.034815> radius 35.91","speed":"-1","latitude":"40.141196","name":"1354 Panther Rd","altitude":"92.00","timeZone":"America\/New_York","isoCountryCode":"US","longitude":"-75.034815","v_accuracy":"65","postalCode":"19006","direction":"-1.0","h_accuracy":"65","subAdministrativeArea":"Montgomery"}
+>{"address":"407 Keats Rd\nLower Moreland PA 19006\nUnited States","locality":"nLower Moreland","subThoroughfare":"407","time":"2019-10-03 04:10:05 +0000","subLocality":null,"administrativeArea":"PA","country":"United States","thoroughfare":"Keats Rd","region":"<+40.141196,-75.034815> radius 35.91","speed":"-1","latitude":"40.141196","name":"1354 Panther Rd","altitude":"92.00","timeZone":"America\/New_York","time_local": "2019-10-02 23:10:05 -0400","isoCountryCode":"US","longitude":"-75.034815","v_accuracy":"65","postalCode":"19006","direction":"-1.0","h_accuracy":"65","subAdministrativeArea":"Montgomery"}
 >  ```
 
 ## Installation


### PR DESCRIPTION
Since an inferred timezone is returned as part of the placemark data, it can be used to localize the timestamp string given in the JSON blob, as well as the string data (if `requiresPlaceMarkLookup` is toggled on as the result of one of the other format specifiers).

This PR just alters the `time` field (in both the JSON output and the formatted string output) to use the user's inferred timezone if available – it outputs in exactly the same format as the default, but will use the correct timezone instead of UTC. If this isn't available, it falls back to UTC (the existing behavior).