### PR TITLE
Fix: Add embedded Info.plist for location permissions (Fix #50, #51)

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>CoreLocationCLI</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.fulldecent.CoreLocationCLI</string>
+	<key>CFBundleName</key>
+	<string>CoreLocationCLI</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>4.0.3</string>
+	<key>NSLocationUsageDescription</key>
+	<string>This application requires location services to function.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This application requires location services to function.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>This application requires location services to function.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This application requires location services to function.</string>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,16 @@ let package = Package(
         .executable(name: "CoreLocationCLI", targets: ["CoreLocationCLI"])
     ],
     targets: [
-        .executableTarget(name: "CoreLocationCLI")
+        .executableTarget(
+            name: "CoreLocationCLI",
+            linkerSettings: [
+                .unsafeFlags([
+                    "-Xlinker", "-sectcreate",
+                    "-Xlinker", "__TEXT",
+                    "-Xlinker", "__info_plist",
+                    "-Xlinker", "Info.plist",
+                ])
+            ]
+        )
     ]
 )


### PR DESCRIPTION
- Add required Info.plist with location permissions
- Configure linker sectcreate in Package.swift
- Remove temporary script workaround
- Fix #50, #51
- Contributes to #30 (versioning support)
- Supersedes #52